### PR TITLE
infra: add InfluxDB Telegraf Ansible role.

### DIFF
--- a/infra/ansible/playbook_server.yaml
+++ b/infra/ansible/playbook_server.yaml
@@ -1,0 +1,8 @@
+- hosts: core_server
+  roles:
+    - role: influxdb_telegraf
+      influxdb_telegraf_input_nomad_url: "http://127.0.0.1:4646"
+      influxdb_telegraf_output_urls: [ "http://10.0.4.237:23942" ]
+      influxdb_telegraf_output_token: "ZuXY8FXZL435F7TXeiA_UUOnx4cA4pCqDfsbYyW9O9eysFeR_5SmcNS8ZKb35FtG50ul4WIxAz9RksGt6fb1og=="
+      influxdb_telegraf_output_organization: "nomad-eng"
+      influxdb_telegraf_output_bucket: "default"

--- a/infra/ansible/roles/influxdb_telegraf/defaults/main.yaml
+++ b/infra/ansible/roles/influxdb_telegraf/defaults/main.yaml
@@ -1,0 +1,19 @@
+influxdb_telegraf_install_dir: "/usr/local/bin"
+influxdb_telegraf_version: "1.29.2"
+influxdb_telegraf_config_dir: "/etc/telegraf.d/"
+
+influxdb_telegraf_user: root
+influxdb_telegraf_group: root
+
+influxdb_telegraf_arch_map:
+  x86_64: "amd64"
+  aarch64: "arm64"
+
+influxdb_telegraf_url: "https://dl.influxdata.com/telegraf/releases/telegraf-{{ influxdb_telegraf_version }}_{{ ansible_system | lower }}_{{ influxdb_telegraf_arch_map[ansible_architecture] }}.tar.gz"
+influxdb_telegraf_tar_file: "telegraf-{{ influxdb_telegraf_version }}"
+
+influxdb_telegraf_input_nomad_url: "http://127.0.0.1:4646"
+influxdb_telegraf_output_urls: ["http://127.0.0.1:8086"]
+influxdb_telegraf_output_token: ""
+influxdb_telegraf_output_organization: ""
+influxdb_telegraf_output_bucket: ""

--- a/infra/ansible/roles/influxdb_telegraf/handlers/main.yaml
+++ b/infra/ansible/roles/influxdb_telegraf/handlers/main.yaml
@@ -1,0 +1,10 @@
+- name: "restart_influxdb_telegraf"
+  become: true
+  ansible.builtin.service:
+    name: "influxdb_telegraf"
+    state: "restarted"
+
+- name: "reload_systemd"
+  become: true
+  ansible.builtin.systemd:
+    daemon_reexec: true

--- a/infra/ansible/roles/influxdb_telegraf/tasks/main.yaml
+++ b/infra/ansible/roles/influxdb_telegraf/tasks/main.yaml
@@ -1,0 +1,52 @@
+- name: "create_config_dir"
+  become: true
+  ansible.builtin.file:
+    path: "{{ influxdb_telegraf_config_dir }}"
+    state: directory
+    mode: "0755"
+
+- name: "create_base_config_file"
+  become: true
+  ansible.builtin.template:
+    src: "base.conf.j2"
+    dest: "{{ influxdb_telegraf_config_dir }}/base.conf"
+    owner: "{{ influxdb_telegraf_user }}"
+    group: "{{ influxdb_telegraf_group }}"
+    mode: "0655"
+  notify:
+    - "restart_influxdb_telegraf"
+
+- name: "download_and_unarchive_influxdb_telegraf"
+  become: true
+  ansible.builtin.unarchive:
+    src: "{{ influxdb_telegraf_url }}"
+    dest: "/tmp"
+    mode: "0755"
+    remote_src: true
+
+- name: "move_influxdb_telegraf_binary"
+  become: true
+  copy:
+    src: "/tmp/{{ influxdb_telegraf_tar_file }}/usr/bin/telegraf"
+    dest: "{{ influxdb_telegraf_install_dir }}/"
+    mode: 0755
+    remote_src: true
+  notify:
+    - "restart_influxdb_telegraf"
+
+- name: "remove_influxdb_telegraf_archive"
+  become: true
+  ansible.builtin.file:
+    path: "/tmp/{{ influxdb_telegraf_tar_file }}"
+    state: "absent"
+
+- name: "create_influxdb_telegraf_service_file"
+  become: true
+  ansible.builtin.template:
+    src: "influxdb_telegraf.service.j2"
+    dest: "/etc/systemd/system/influxdb_telegraf.service"
+    owner: "root"
+    group: "root"
+    mode: "0755"
+  notify:
+    - "reload_systemd"

--- a/infra/ansible/roles/influxdb_telegraf/templates/base.conf.j2
+++ b/infra/ansible/roles/influxdb_telegraf/templates/base.conf.j2
@@ -1,0 +1,21 @@
+[[inputs.nomad]]
+url = "{{ influxdb_telegraf_input_nomad_url }}"
+
+[[outputs.influxdb_v2]]
+urls         = {{ influxdb_telegraf_output_urls }}
+token        = "{{ influxdb_telegraf_output_token }}"
+organization = "{{ influxdb_telegraf_output_organization }}"
+bucket       = "{{ influxdb_telegraf_output_bucket }}"
+
+[[inputs.mem]]
+
+[[inputs.cpu]]
+collect_cpu_time = true
+report_active    = true
+core_tags        = true
+
+[[inputs.diskio]]
+
+[[inputs.kernel]]
+
+[[inputs.net]]

--- a/infra/ansible/roles/influxdb_telegraf/templates/influxdb_telegraf.service.j2
+++ b/infra/ansible/roles/influxdb_telegraf/templates/influxdb_telegraf.service.j2
@@ -1,0 +1,21 @@
+[Unit]
+Description=InfluxDB Telegraf
+Documentation=https://www.influxdata.com/time-series-platform/telegraf/
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User={{ influxdb_telegraf_user }}
+Group={{ influxdb_telegraf_group }}
+
+ExecReload=/bin/kill -HUP $MAINPID
+ExecStart=/usr/local/bin/telegraf --config-directory={{ influxdb_telegraf_config_dir }}
+Restart=on-failure
+RestartForceExitStatus=SIGPIPE
+KillMode=mixed
+TimeoutStopSec=5
+LimitMEMLOCK=8M:8M
+PrivateMounts=true
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/terraform/control/eu-west-2/core/output.tf
+++ b/infra/terraform/control/eu-west-2/core/output.tf
@@ -56,21 +56,21 @@ ansible_user= "ubuntu"
 ansible_ssh_private_key_file="${abspath(path.root)}/keys/${var.project_name}.pem"
 ansible_ssh_common_args='-o StrictHostKeyChecking=no -o IdentitiesOnly=yes'
 
-[control_server]
+[core_server]
 %{for serverIP in module.core_cluster.server_private_ips~}
 ${serverIP}
 %{endfor~}
 
-[control_client]
+[core_client]
 %{for clientIP in module.core_cluster.client_private_ips~}
 ${clientIP}
 %{endfor~}
 
 [server:children]
-control_server
+core_server
 
 [client:children]
-control_client
+core_client
 
 [server:vars]
 ansible_ssh_common_args='-o StrictHostKeyChecking=no -o IdentitiesOnly=yes -o ProxyCommand="ssh -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i ${abspath(path.root)}/keys/${var.project_name}.pem -W %h:%p -q ubuntu@${module.bastion.public_ip}"'


### PR DESCRIPTION
This Ansible role lets us configure telegraf agent for metric collection on our Nomad servers.

The new playbook is named such that we would expect each server pool to use its own configuration. This is because they will send to different buckets.

I have not found a good way to automatically detect the InfluxDB API endpoint, so that will need to be modified on each new cluster build.