### PR TITLE
traefik: correctly account for Nomad running TLS.

### DIFF
--- a/infra/jobs/traefik.nomad.hcl
+++ b/infra/jobs/traefik.nomad.hcl
@@ -1,3 +1,8 @@
+variable "tls_ca_path" {
+  description = "The local path to the Nomad CA certificate."
+  type        = string
+}
+
 job "traefik" {
   type = "system"
 
@@ -37,6 +42,11 @@ job "traefik" {
       }
 
       template {
+        data        = file(var.tls_ca_path)
+        destination = "${NOMAD_TASK_DIR}/ca.pem"
+      }
+
+      template {
         destination = "${NOMAD_TASK_DIR}/traefik.yml"
         data        = <<-EOH
 api:
@@ -59,6 +69,11 @@ providers:
     stale: true
     endpoint:
       address: https://{{ env "NOMAD_IP_api" }}:4646
+      tls:
+        ca: {{ env "NOMAD_TASK_DIR" }}/ca.pem
+
+serversTransport:
+  insecureSkipVerify: true
 EOH
       }
 

--- a/infra/terraform/control/eu-west-2/core/output.tf
+++ b/infra/terraform/control/eu-west-2/core/output.tf
@@ -31,7 +31,11 @@ If you are deploying Traefik and InfluxDB to this cluster, the following command
 perform the initial job registrations. Once the allocations have been started, Traefik will be
 available on your LB at port 8080, and InfluxDB at port 8086. If you need to customize any of
 the jobs via the available variables, please check the job specificaitons.
-  nomad run -address=https://${module.core_cluster_lb.lb_dns_name}:80 ../../../../jobs/traefik.nomad.hcl
+  nomad run \
+    -address=https://${module.core_cluster_lb.lb_dns_name}:80 \
+    -var='tls_ca_path=${module.core_cluster.ca_cert_path}' \
+    ../../../../jobs/traefik.nomad.hcl
+
   nomad run -address=https://${module.core_cluster_lb.lb_dns_name}:80 ../../../../jobs/influxdb.nomad.hcl
 EOM
 }


### PR DESCRIPTION
Traefik uses Nomad as a provider and therefore need access to the Nomad API. This change accounts for Nomad running TLS and modifies the output file to detail the correct way to register the job.