### PR TITLE
infra: use Telegraf to tail and ship Nomad logs to InfluxDB.

### DIFF
--- a/infra/ansible/playbook_eu-west-2_core_server.yaml
+++ b/infra/ansible/playbook_eu-west-2_core_server.yaml
@@ -12,8 +12,9 @@
 
     - role: influxdb_telegraf
       vars:
-        influxdb_telegraf_input_nomad_url: "http://127.0.0.1:4646"
-        influxdb_telegraf_output_urls: [ "http://10.0.4.237:23942" ]
+        influxdb_telegraf_input_nomad_url: "https://127.0.0.1:4646"
+        influxdb_telegraf_input_nomad_tls_ca: "/etc/nomad.d/tls/ca.pem"
+        influxdb_telegraf_output_urls: [ "http://10.0.4.158:20762" ]
         influxdb_telegraf_output_token: "ZuXY8FXZL435F7TXeiA_UUOnx4cA4pCqDfsbYyW9O9eysFeR_5SmcNS8ZKb35FtG50ul4WIxAz9RksGt6fb1og=="
         influxdb_telegraf_output_organization: "nomad-eng"
         influxdb_telegraf_output_bucket: "default"

--- a/infra/ansible/roles/influxdb_telegraf/defaults/main.yaml
+++ b/infra/ansible/roles/influxdb_telegraf/defaults/main.yaml
@@ -13,6 +13,8 @@ influxdb_telegraf_url: "https://dl.influxdata.com/telegraf/releases/telegraf-{{ 
 influxdb_telegraf_tar_file: "telegraf-{{ influxdb_telegraf_version }}"
 
 influxdb_telegraf_input_nomad_url: "http://127.0.0.1:4646"
+influxdb_telegraf_input_nomad_tls_ca: ""
+influxdb_telegraf_inout_nomad_log_file: "/var/log/nomad.log"
 influxdb_telegraf_output_urls: ["http://127.0.0.1:8086"]
 influxdb_telegraf_output_token: ""
 influxdb_telegraf_output_organization: ""

--- a/infra/ansible/roles/influxdb_telegraf/tasks/main.yaml
+++ b/infra/ansible/roles/influxdb_telegraf/tasks/main.yaml
@@ -16,6 +16,17 @@
   notify:
     - "restart_influxdb_telegraf"
 
+- name: "stat_telegraf_binary"
+  stat: path="{{ influxdb_telegraf_install_dir }}/telegraf"
+  register: telegraf_binary
+
+- name: "check_telegraf_binary_version"
+  shell: "{{ influxdb_telegraf_install_dir }}/telegraf version"
+  register: telegraf_binary_version
+  when: telegraf_binary.stat.exists
+  changed_when: false
+  failed_when: false
+
 - name: "download_and_unarchive_influxdb_telegraf"
   become: true
   ansible.builtin.unarchive:
@@ -23,6 +34,7 @@
     dest: "/tmp"
     mode: "0755"
     remote_src: true
+  when: "not telegraf_binary.stat.exists or telegraf_binary_version is not defined or influxdb_telegraf_version|string not in telegraf_binary_version.stdout"
 
 - name: "move_influxdb_telegraf_binary"
   become: true
@@ -31,6 +43,7 @@
     dest: "{{ influxdb_telegraf_install_dir }}/"
     mode: 0755
     remote_src: true
+  when: "not telegraf_binary.stat.exists or telegraf_binary_version is not defined or influxdb_telegraf_version|string not in telegraf_binary_version.stdout"
   notify:
     - "restart_influxdb_telegraf"
 

--- a/infra/ansible/roles/influxdb_telegraf/templates/base.conf.j2
+++ b/infra/ansible/roles/influxdb_telegraf/templates/base.conf.j2
@@ -1,5 +1,6 @@
 [[inputs.nomad]]
-url = "{{ influxdb_telegraf_input_nomad_url }}"
+url    = "{{ influxdb_telegraf_input_nomad_url }}"
+tls_ca = "{{ influxdb_telegraf_input_nomad_tls_ca }}"
 
 [[outputs.influxdb_v2]]
 urls         = {{ influxdb_telegraf_output_urls }}
@@ -19,3 +20,10 @@ core_tags        = true
 [[inputs.kernel]]
 
 [[inputs.net]]
+
+[[inputs.tail]]
+  files              = ["{{ influxdb_telegraf_inout_nomad_log_file }}"]
+  data_format        = "json"
+  json_string_fields = ["@level", "@module", "@message", "@caller"]
+  json_time_key      = "@timestamp"
+  json_time_format   = "2006-01-02T15:04:05Z07:00"


### PR DESCRIPTION
This change enables the Telegraf tail input to track the Nomad server logs for shipping to InfluxDB. The Telegraf config file is also updated to account for Nomad running TLS.

The Telegraf install task has also been updated so it does not blindly install, and checks for both the binary existing and its version.