### PR TITLE
core: allow ingress ip for lgfa29

### DIFF
--- a/infra/eu-west-2/core/terraform.tfvars
+++ b/infra/eu-west-2/core/terraform.tfvars
@@ -1,5 +1,6 @@
 region       = "eu-west-2"
 project_name = "bench-core"
 
-jrasell_ip      = "5.80.87.58/32"
-pkazmierczak_ip = "95.98.54.163/32"
+jrasell_ip      = "5.80.87.58"
+pkazmierczak_ip = "95.98.54.163"
+lgfa29_ip       = "66.23.103.198"

--- a/infra/eu-west-2/core/variables.tf
+++ b/infra/eu-west-2/core/variables.tf
@@ -2,3 +2,4 @@ variable "region" {}
 variable "project_name" {}
 variable "jrasell_ip" {}
 variable "pkazmierczak_ip" {}
+variable "lgfa29_ip" {}


### PR DESCRIPTION
I kept forgetting to add the `/32` 😅 

Unless one of you has bought a CIDR block, I think it's safe to assume `/32`.