### PR TITLE
core: use single playbook provisioning

### DIFF
--- a/infra/eu-west-2/core/ansible/playbook.yaml
+++ b/infra/eu-west-2/core/ansible/playbook.yaml
@@ -1,0 +1,4 @@
+- ansible.builtin.import_playbook: "playbook_bastion.yaml"
+- ansible.builtin.import_playbook: "playbook_server.yaml"
+- ansible.builtin.import_playbook: "playbook_client.yaml"
+- ansible.builtin.import_playbook: "playbook_lb.yaml"

--- a/shared/terraform/modules/nomad-output/output.tf
+++ b/shared/terraform/modules/nomad-output/output.tf
@@ -78,12 +78,7 @@ Open SSH tunnel to Nomad:
 
 In order to provision the cluster, you can run the following command which will trigger the Ansible
 playbooks:
-  cd ./ansible && \
-    ansible-playbook ./playbook_bastion.yaml && \
-    ansible-playbook ./playbook_server.yaml && \
-    ansible-playbook ./playbook_client.yaml && \
-    ansible-playbook ./playbook_lb.yaml && \
-    cd ..
+  cd ./ansible && ansible-playbook ./playbook.yaml && cd ..
 
 CA, Certs, and Keys for Nomad have been provisioned here:
   ${var.tls_certs_root_path}/


### PR DESCRIPTION
Create a unified playbook that imports the other playbooks to allow for single command provisioning.

I think is a better approach than moving all plays to a single playbook. This way we can still run individual playbooks if needed, but there's a single one to run everything.