### PR TITLE
ansible: refactore nomad role ACL tasks

### DIFF
--- a/infra/eu-west-2/core/ansible/playbook_nuke_state.yaml
+++ b/infra/eu-west-2/core/ansible/playbook_nuke_state.yaml
@@ -1,0 +1,29 @@
+- hosts: server:client
+  gather_facts: false
+  tasks:
+    - block:
+        - name: "stop_nomad"
+          become: true
+          ansible.builtin.service:
+            name: "nomad"
+            state: "stopped"
+        - name: "delete_data_dir"
+          become: true
+          ansible.builtin.file:
+            path: "/opt/nomad/data"
+            state: "absent"
+        - name: "restart_nomad"
+          become: true
+          ansible.builtin.service:
+            name: "nomad"
+            state: "started"
+            enabled: true
+      tags:
+        - "nuke"
+        - "never"
+    - name: ""
+      ansible.builtin.fail:
+        msg: "This playbook deletes all Nomad state. Use --tags=nuke to confirm Nomad data deletion"
+      when: "'nuke' not in ansible_run_tags"
+      run_once: true
+      delegate_to: localhost

--- a/shared/ansible/requirements.txt
+++ b/shared/ansible/requirements.txt
@@ -3,6 +3,7 @@ ansible-core==2.16.3
 cffi==1.16.0
 cryptography==42.0.2
 Jinja2==3.1.3
+jmespath==1.0.1
 MarkupSafe==2.1.4
 packaging==23.2
 pycparser==2.21

--- a/shared/ansible/roles/nomad/defaults/main.yaml
+++ b/shared/ansible/roles/nomad/defaults/main.yaml
@@ -43,3 +43,4 @@ nomad_cli_tls_cert: ""
 nomad_cli_tls_cert_key: ""
 
 nomad_acl_enabled: false
+nomad_acl_bootstrap_token_dest_path: "nomad-token"

--- a/shared/ansible/roles/nomad/files/acl.hcl
+++ b/shared/ansible/roles/nomad/files/acl.hcl
@@ -1,3 +1,0 @@
-acl {
-  enabled = true
-}

--- a/shared/ansible/roles/nomad/tasks/acl_bootstrap.yaml
+++ b/shared/ansible/roles/nomad/tasks/acl_bootstrap.yaml
@@ -1,37 +1,27 @@
-- name: "write_acl_conf"
-  become: true
-  ansible.builtin.copy:
-    dest: "{{ nomad_config_dir }}/acl.hcl"
-    src: "acl.hcl"
-    owner: "{{ nomad_user }}"
-    group: "{{ nomad_group }}"
-    mode: "0644"
-
-- name: "restart_nomad"
-  become: true
-  ansible.builtin.service:
-    name: nomad
-    state: restarted
-
 - name: "bootstrap_acl"
   run_once: true
   ansible.builtin.command: "nomad acl bootstrap -json"
-  environment: 
+  environment:
     NOMAD_ADDR: "https://127.0.0.1:4646"
     NOMAD_CACERT: "{{ nomad_config_dir }}/tls/ca.pem"
     NOMAD_CLIENT_CERT: "{{ nomad_config_dir }}/tls/cli.pem"
     NOMAD_CLIENT_KEY: "{{ nomad_config_dir }}/tls/cli-key.pem"
   register: nomad_acl
-  when: inventory_hostname in groups["server"]
-  ignore_errors: true   # bootstrap ACL will only ever succeed once
+
+- name: "save_bootstrap_token"
+  run_once: true
+  ansible.builtin.set_fact:
+    nomad_acl_bootstrap_token: "{{
+      nomad_acl.stdout \
+      | ansible.builtin.from_json \
+      | community.general.json_query('SecretID') \
+    }}"
 
 - name: "store_bootstrap_token"
   run_once: true
   ansible.builtin.copy:
-    content: "{{ nomad_acl.stdout | from_json | json_query('SecretID') }}"
-    dest: "nomad-token"
-  when: inventory_hostname in groups["server"]
-  ignore_errors: true   # bootstrap ACL will only ever succeed once
+    content: "{{ nomad_acl_bootstrap_token }}"
+    dest: "{{ nomad_acl_bootstrap_token_dest_path }}"
   delegate_to: localhost
 
 - name: "write_anonymous_policy"
@@ -45,14 +35,13 @@
   when: inventory_hostname in groups["server"]
 
 - name: "apply_acl_policy"
+  run_once: true
   environment:
     NOMAD_ADDR: "https://127.0.0.1:4646"
     NOMAD_CACERT: "{{ nomad_config_dir }}/tls/ca.pem"
     NOMAD_CLIENT_CERT: "{{ nomad_config_dir }}/tls/cli.pem"
     NOMAD_CLIENT_KEY: "{{ nomad_config_dir }}/tls/cli-key.pem"
-    NOMAD_TOKEN: "{{ nomad-token.stdout }}"
+    NOMAD_TOKEN: "{{ nomad_acl_bootstrap_token }}"
   ansible.builtin.command: "nomad acl policy \
-   apply -description \"Anonymous policy (full-access)\" \ 
-   anonymous /home/ubuntu/anonymous.policy.hcl" 
-  ignore_errors: true   # bootstrap ACL will only ever succeed once
-  when: inventory_hostname in groups["server"]
+   apply -description \"Anonymous policy (full-access)\" \
+   anonymous /home/ubuntu/anonymous.policy.hcl"

--- a/shared/ansible/roles/nomad/tasks/main.yaml
+++ b/shared/ansible/roles/nomad/tasks/main.yaml
@@ -103,7 +103,9 @@
     - "never"
     - "custom_build"
 
-- name: "acl"
-  ansible.builtin.include_tasks:
-    file: acl.yaml
-  when: nomad_acl_enabled is true
+- name: "acl_bootstrap"
+  ansible.builtin.import_tasks:
+    file: acl_bootstrap.yaml
+  tags:
+    - acl_bootstrap
+    - never

--- a/shared/ansible/roles/nomad/templates/base.hcl.j2
+++ b/shared/ansible/roles/nomad/templates/base.hcl.j2
@@ -20,3 +20,7 @@ telemetry {
   publish_node_metrics       = {{ nomad_telemetry_publish_node_metrics | lower }}
   prometheus_metrics         = {{ nomad_telemetry_prometheus_metrics | lower }}
 }
+
+acl {
+  enabled = {{ nomad_acl_enabled | lower }}
+}


### PR DESCRIPTION
Apply the following changes to ACL handling in the `nomad` role:

- Guard ACL bootstrap with an opt-in tag. Since this is an operation we expect to only do once per cluster, it should be an opt-in action that is explicitly requested by operators.
- Write Noamd ACL config in the base config task. This ensures that the configuration file is updated when flipping between `true` and `false`.
- Fix loading the Noamd bootstrap token into the `NOMAD_TOKEN` environment variable. Previously the task was reading from the wrong variable. Setting it as a fact allows easier access by other tasks.
- Add `playbook_nuke_state.yaml` to help development. Since ACL bootstrap can only be done once we need to delete state before trying the role again.