### PR TITLE
ansible: remove nomad binary before build

### DIFF
--- a/shared/ansible/roles/build/tasks/main.yaml
+++ b/shared/ansible/roles/build/tasks/main.yaml
@@ -28,6 +28,11 @@
         - "--exclude=.semgrep"
         - "--exclude=.tours"
 
+  - name: "remove_nomad_binary"
+    ansible.builtin.file:
+      path:  "/home/{{ build_user }}/nomad/pkg/linux_amd64/nomad"
+      state: "absent"
+
   - name: "build_nomad_binary"
     shell: ". /etc/profile;make pkg/linux_amd64/nomad"
     args:


### PR DESCRIPTION
The makefile doesn't build the Nomad binary if it already exists in the target path, so remove it before the build.