### PR TITLE
ansible: adjust vars and set values from Terraform

### DIFF
--- a/infra/eu-west-2/core/ansible/playbook_client.yaml
+++ b/infra/eu-west-2/core/ansible/playbook_client.yaml
@@ -10,13 +10,13 @@
     - role: nomad
       vars:
         nomad_client_enabled: true
-        nomad_server_join_retry_join: [ "provider=aws tag_key=Nomad_role tag_value={{ project_name }}_server" ]
+        nomad_server_join_retry_join: ["{{ terraform_nomad_server_join }}"]
         nomad_telemetry_publish_allocation_metrics: true
         nomad_telemetry_publish_node_metrics: true
         nomad_tls_enable: true
         nomad_tls_ca_cert: "{{ lookup('file', '../tls/nomad-agent-ca.pem') }}"
-        nomad_tls_cert: "{{ lookup('file', '../tls/{{ nomad_region }}-client-nomad.pem') }}"
-        nomad_tls_cert_key: "{{ lookup('file', '../tls/{{ nomad_region }}-client-nomad-key.pem') }}"
+        nomad_tls_cert: "{{ lookup('file', '../tls/global-client-nomad.pem') }}"
+        nomad_tls_cert_key: "{{ lookup('file', '../tls/global-client-nomad-key.pem') }}"
         nomad_host_volumes:
           - name: influxdb
             path: /opt/influxdb

--- a/infra/eu-west-2/core/ansible/playbook_lb.yaml
+++ b/infra/eu-west-2/core/ansible/playbook_lb.yaml
@@ -5,8 +5,8 @@
     - role: nomad_lb
       vars:
         nomad_lb_ca_cert: "{{ lookup('file', '../tls/nomad-agent-ca.pem') }}"
-        nomad_lb_tls_cert: "{{ lookup('file', '../tls/{{ nomad_region }}-client-nomad.pem') }}"
-        nomad_lb_tls_cert_key: "{{ lookup('file', '../tls/{{ nomad_region }}-client-nomad-key.pem') }}"
+        nomad_lb_tls_cert: "{{ lookup('file', '../tls/global-client-nomad.pem') }}"
+        nomad_lb_tls_cert_key: "{{ lookup('file', '../tls/global-client-nomad-key.pem') }}"
         # Hack to make the Terraform dynamic inventory plugin work with complex types.
-        nomad_lb_server_ips: "{{ nomad_lb_server_ips_json | ansible.builtin.from_json }}"
-        nomad_lb_client_ips: "{{ nomad_lb_client_ips_json | ansible.builtin.from_json }}"
+        nomad_lb_server_ips: "{{ terraform_server_ips_json | ansible.builtin.from_json }}"
+        nomad_lb_client_ips: "{{ terraform_client_ips_json | ansible.builtin.from_json }}"

--- a/infra/eu-west-2/core/ansible/playbook_server.yaml
+++ b/infra/eu-west-2/core/ansible/playbook_server.yaml
@@ -5,16 +5,16 @@
     - role: nomad
       vars:
         nomad_server_enabled: true
-        nomad_server_join_retry_join: [ "provider=aws tag_key=Nomad_role tag_value={{ project_name }}_server" ]
+        nomad_server_join_retry_join: ["{{ terraform_nomad_server_join }}"]
         nomad_limits_http_max_conns_per_client: 0
         nomad_limits_rpc_max_conns_per_client: 0
         nomad_tls_enable: true
         nomad_tls_ca_cert: "{{ lookup('file', '../tls/nomad-agent-ca.pem') }}"
-        nomad_tls_cert: "{{ lookup('file', '../tls/{{ nomad_region }}-server-nomad.pem') }}"
-        nomad_tls_cert_key: "{{ lookup('file', '../tls/{{ nomad_region }}-server-nomad-key.pem') }}"
+        nomad_tls_cert: "{{ lookup('file', '../tls/global-server-nomad.pem') }}"
+        nomad_tls_cert_key: "{{ lookup('file', '../tls/global-server-nomad-key.pem') }}"
         nomad_cli_profile_enabled: true
-        nomad_cli_tls_cert: "{{ lookup('file', '../tls/{{ nomad_region }}-cli-nomad.pem') }}"
-        nomad_cli_tls_cert_key: "{{ lookup('file', '../tls/{{ nomad_region }}-cli-nomad-key.pem') }}"
+        nomad_cli_tls_cert: "{{ lookup('file', '../tls/global-cli-nomad.pem') }}"
+        nomad_cli_tls_cert_key: "{{ lookup('file', '../tls/global-cli-nomad-key.pem') }}"
         nomad_acl_enabled: true
 
     - role: influxdb_telegraf
@@ -23,5 +23,6 @@
         influxdb_telegraf_input_nomad_tls_ca: "{{ nomad_config_dir }}tls/ca.pem"
         influxdb_telegraf_output_token: "ZuXY8FXZL435F7TXeiA_UUOnx4cA4pCqDfsbYyW9O9eysFeR_5SmcNS8ZKb35FtG50ul4WIxAz9RksGt6fb1og=="
         influxdb_telegraf_output_organization: "nomad-eng"
+        influxdb_telegraf_output_bucket: "{{ terraform_project_name }}"
         # Hack to make the Terraform dynamic inventory plugin work with complex types.
-        influxdb_telegraf_output_urls: "{{ influxdb_telegraf_output_urls_json | ansible.builtin.from_json }}"
+        influxdb_telegraf_output_urls: "{{ terraform_influxdb_telegraf_output_urls_json | ansible.builtin.from_json }}"

--- a/infra/eu-west-2/core/lb.tf
+++ b/infra/eu-west-2/core/lb.tf
@@ -15,8 +15,8 @@ resource "ansible_group" "lb" {
   name = "lb"
   variables = merge(local.ansible_default_vars, {
     ansible_ssh_common_args  = "-o StrictHostKeyChecking=no -o IdentitiesOnly=yes"
-    nomad_lb_server_ips_json = jsonencode(module.core_cluster.server_private_ips)
-    nomad_lb_client_ips_json = jsonencode(module.core_cluster.client_private_ips)
+    terraform_server_ips_json = jsonencode(module.core_cluster.server_private_ips)
+    terraform_client_ips_json = jsonencode(module.core_cluster.client_private_ips)
   })
 }
 

--- a/infra/eu-west-2/core/main.tf
+++ b/infra/eu-west-2/core/main.tf
@@ -79,9 +79,8 @@ resource "ansible_group" "client" {
 resource "ansible_group" "all" {
   name = "all"
   variables = {
-    project_name                       = var.project_name
-    influxdb_telegraf_output_bucket    = var.project_name
-    influxdb_telegraf_output_urls_json = jsonencode([module.core_cluster_lb.lb_private_ip])
+    terraform_project_name                       = var.project_name
+    terraform_influxdb_telegraf_output_urls_json = jsonencode(formatlist("http://%s:8086", [module.core_cluster_lb.lb_private_ip]))
   }
 }
 

--- a/shared/ansible/roles/common/defaults/main.yaml
+++ b/shared/ansible/roles/common/defaults/main.yaml
@@ -1,2 +1,0 @@
-project_name: "nomad-bench"
-nomad_region: "global"

--- a/shared/terraform/modules/nomad-cluster/ansible.tf
+++ b/shared/terraform/modules/nomad-cluster/ansible.tf
@@ -1,5 +1,15 @@
+locals {
+  nomad_aws_server_join = "provider=aws tag_key=Nomad_role tag_value=${aws_instance.servers[0].tags.Nomad_role}"
+}
+
 resource "ansible_group" "server" {
   name = "${replace(var.project_name, "-", "_")}_server"
+  variables = merge(
+    {
+      terraform_nomad_server_join = local.nomad_aws_server_join
+    },
+    var.ansible_server_group_vars,
+  )
 }
 
 resource "ansible_host" "server" {
@@ -14,6 +24,12 @@ resource "ansible_host" "server" {
 
 resource "ansible_group" "client" {
   name = "${replace(var.project_name, "-", "_")}_client"
+  variables = merge(
+    {
+      terraform_nomad_server_join = local.nomad_aws_server_join
+    },
+    var.ansible_client_group_vars,
+  )
 }
 
 resource "ansible_host" "client" {

--- a/shared/terraform/modules/nomad-cluster/variables.tf
+++ b/shared/terraform/modules/nomad-cluster/variables.tf
@@ -28,6 +28,11 @@ variable "server_count" {
   description = "The number of servers to provision."
   type        = number
   default     = "3"
+
+  validation {
+    condition     = var.server_count >= 1
+    error_message = "A Nomad cluster must have at least one server."
+  }
 }
 
 variable "server_instance_type" {
@@ -58,4 +63,14 @@ variable "client_iops" {
   description = "iops for the root block device of the nomad clients"
   type        = string
   default     = "3600"
+}
+
+variable "ansible_server_group_vars" {
+  type    = map(string)
+  default = {}
+}
+
+variable "ansible_client_group_vars" {
+  type    = map(string)
+  default = {}
 }


### PR DESCRIPTION
Set Ansible host and group variables from values defined in Terraform to keep them more consistent when values change and make the playbooks more dynamic. Variables defined exclusively on Terraform are prefixed with `terraform_` to make it clear what their source is.

The `nomad-cluster` module was expanded to accept additional Ansible variables for the `server` and `client` groups, which will be helpful when creating test clusters.

The `nomad_region` variable was being declared twice (in the `common` and `nomad` roles) which can lead to unexpect results as Ansible doesn't guarantee precedence in this case. Since the `nomad-tls` module doesn't support specifying the region, and always uses `global` in the path, using a variable to lookup the certificates could result in the incorrect path.

Also fixes the format for the InfluxDB URL in the Telegraf configuration and the load balancer IP list for clients.