### PR TITLE
ansible: make Nomad TLS CA optional for Telegraf

### DIFF
--- a/shared/ansible/roles/influxdb_telegraf/templates/base.conf.j2
+++ b/shared/ansible/roles/influxdb_telegraf/templates/base.conf.j2
@@ -1,6 +1,8 @@
 [[inputs.nomad]]
 url    = "{{ influxdb_telegraf_input_nomad_url }}"
+{% if influxdb_telegraf_input_nomad_tls_ca != "" %}
 tls_ca = "{{ influxdb_telegraf_input_nomad_tls_ca }}"
+{% endif %}
 
 [[outputs.influxdb_v2]]
 urls         = {{ influxdb_telegraf_output_urls }}


### PR DESCRIPTION
When the Nomad cluster is provisioned wihtout mTLS, the TLS CA certificate is not necessary in the Telegraf configuration.