### PR TITLE
ansible: set `roles_path` in the project root

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path=./shared/ansible/roles


### PR DESCRIPTION
When installing roles from Ansible Galaxy they need to be placed in the shared Ansible roles folder so that infrastructure playbooks can use them.