### PR TITLE
core: resize Nomad cluster

### DIFF
--- a/infra/eu-west-2/core/ansible/playbook_server.yaml
+++ b/infra/eu-west-2/core/ansible/playbook_server.yaml
@@ -5,6 +5,7 @@
     - role: nomad
       vars:
         nomad_server_enabled: true
+        nomad_server_bootstrap_expect: 1
         nomad_server_join_retry_join: ["{{ terraform_nomad_server_join }}"]
         nomad_limits_http_max_conns_per_client: 0
         nomad_limits_rpc_max_conns_per_client: 0

--- a/infra/eu-west-2/core/main.tf
+++ b/infra/eu-west-2/core/main.tf
@@ -54,9 +54,10 @@ module "core_cluster" {
   source = "../../../shared/terraform/modules/nomad-cluster"
 
   project_name         = var.project_name
-  server_instance_type = "t3.micro"
-  client_count         = 1
-  client_instance_type = "t3.micro"
+  server_count         = 1
+  server_instance_type = "t3.medium"
+  client_count         = 2
+  client_instance_type = "t3.small"
   ami                  = data.aws_ami.ubuntu.id
   subnet_ids           = module.network.private_subnet_ids
   key_name             = module.ssh.key_name


### PR DESCRIPTION
We are probably better off with a single server than 3 small ones since we will be mostly running ephemeral nodesim jobs.

Also increased the number of clients to support multiple the nodesim jobs.

We may need to adjust our data persistence strategy for influxdb, since the `nomad` Ansible role creates the same host volumes in all clients.