### PR TITLE
core: use Terraform Cloud as backend

### DIFF
--- a/.terraformignore
+++ b/.terraformignore
@@ -1,0 +1,5 @@
+shared/ansible/
+tools/
+.terraform/
+keys/
+tls/

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ make deps
 
 ### Provision core infrastructure
 
+Login to Terraform Cloud.
+
+```console
+terraform login
+```
+
 Run Terraform from the `./infra/eu-west-2/core` directory.
 
 ```console

--- a/infra/eu-west-2/core/.terraform.lock.hcl
+++ b/infra/eu-west-2/core/.terraform.lock.hcl
@@ -1,6 +1,36 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "doormat.hashicorp.services/hashicorp-security/doormat" {
+  version     = "0.0.10"
+  constraints = "~> 0.0.2"
+  hashes = [
+    "h1:c0s337fFwGvks1VCApAIvRGSLOOjAwevfc4/RBzbfzM=",
+    "zh:0dc4db52279230067d0398a8cd20f4dc6f2e76e18d9e2a7a458ba0448605f88c",
+    "zh:11e7b93acbed90b1a53f7928372d51e18196be6dfe60c446f4151d03567819ff",
+    "zh:2a0a8c792ef1cbfc0e112e341efa99e2aa12d80506cb83a9eb740141d2abbd0d",
+    "zh:2ae5343d1e1a79fd692916d52d7b5f7c24f9499baa8c20164e2b84bede746363",
+    "zh:3d3eebf7362f2668ebec92c9f9b1450b40ec10b6b776fc930ea8230ffa36c899",
+    "zh:41a72e946dea7b88e03df5f008782fb2e5fd3ef17e5ca0b29e9ac3551190c350",
+    "zh:45b5755bcd275a3d1fa78e33284eb81e752bf531f94c499e7b609b0092692e9f",
+    "zh:5b3b43633f4e8066b1f633963fd2ef421a41ccf54bda8779fa55cbdde297ad9b",
+    "zh:6cb74995b6c15ae97bc9467a8370f3edb2578e01ed77826fc74505220fd0b57d",
+    "zh:6e06bd2de9835e76aae8a7195fd2112aa45ccc3b25776a0381e0dbb0cdf7ca15",
+    "zh:75077a2c195d0ebf2e0fdabaf8c487aa0c916756cea2bfd71d42fcfc749eb7c9",
+    "zh:7c795080459da0b17b37161f4e0fd0f1bfdb537382a6af44eefe3c1dc6540fd3",
+    "zh:7f660caef9fa419ec5886ff056dc7b904b2cd6b00b8deab7a84ff81db2db20d5",
+    "zh:7fd7fc1cf7ddafc3568ab495c8321a7142a8565f5dfaede270dc439121e649dd",
+    "zh:90c5ea86efcd19a035ff15fcbaece9a147b44d4a2a1dabe5953104ba87264825",
+    "zh:9298f546a84af1470bf6cc94328090e06edad98c5b07b4ed47347ff0d1ee8a7f",
+    "zh:97878762075c2b61b036683631e32879eb04bbac50a350a67aa83370698b48fd",
+    "zh:9d6bd68bf9fb8715ee145a8fc0408bebebaabbac94ed8093184eb2a9f80badf5",
+    "zh:b1f521477aa7d86d69d25eb5096c6246a24d7ed22ce31f2470f8f7349bb40e73",
+    "zh:bf6d6e6a935c76d70243d5c5e166c3ac926a1655184870acae86adfebdd20a4b",
+    "zh:c8eb7ef826c35946d2482062c5df1b85ce91c457fc31f754f71200c6086fd76a",
+    "zh:e474aed6a615a7327c6e0da16f26c8012ea443d90d6cb8f6ffa67116b5e253c3",
+  ]
+}
+
 provider "registry.terraform.io/ansible/ansible" {
   version     = "1.1.0"
   constraints = "~> 1.1.0"

--- a/infra/eu-west-2/core/main.tf
+++ b/infra/eu-west-2/core/main.tf
@@ -89,6 +89,6 @@ module "output" {
 
   project_name               = var.project_name
   bastion_host_public_ip     = module.bastion.public_ip
-  tls_certs_root_path        = "${path.cwd}/tls"
+  tls_certs_root_path        = "$PWD/tls"
   nomad_lb_public_ip_address = module.core_cluster_lb.lb_public_ip
 }

--- a/infra/eu-west-2/core/provider.tf
+++ b/infra/eu-west-2/core/provider.tf
@@ -1,19 +1,35 @@
 terraform {
-  backend "s3" {
-    bucket         = "nomad-bench"
-    key            = "tf-state/eu-west-2/bench-core"
-    region         = "eu-west-2"
-    dynamodb_table = "nomad-bench-terraform-state-lock"
+  cloud {
+    organization = "nomad-eng"
+
+    workspaces {
+      name = "nomad-bench-core"
+    }
   }
 
   required_providers {
     ansible = {
-      version = "~> 1.1.0"
       source  = "ansible/ansible"
+      version = "~> 1.1.0"
+    }
+    doormat = {
+      source  = "doormat.hashicorp.services/hashicorp-security/doormat"
+      version = "~> 0.0.2"
     }
   }
 }
 
+provider "doormat" {}
+
 provider "aws" {
   region = var.region
+
+  access_key = data.doormat_aws_credentials.creds.access_key
+  secret_key = data.doormat_aws_credentials.creds.secret_key
+  token      = data.doormat_aws_credentials.creds.token
+}
+
+data "doormat_aws_credentials" "creds" {
+  provider = doormat
+  role_arn = "arn:aws:iam::999225027745:role/tfc-doormat-nomad-bench-core"
 }


### PR DESCRIPTION
Since we're storing credentials for long-running infrastructure it may be better to store them in a HashiCorp service instead of a random S3 bucket.

TFC also provides more visibility on changes and can be useful when debugging problems with the rest of the team.

It also doesn't require AWS credentials from Doormat to be loaded into the local machine.