### PR TITLE
core: bump client instance size and influxdb mem

### DIFF
--- a/infra/eu-west-2/core/main.tf
+++ b/infra/eu-west-2/core/main.tf
@@ -73,7 +73,7 @@ module "core_cluster" {
   server_count         = 1
   server_instance_type = "t3.medium"
   client_count         = 2
-  client_instance_type = "t3.small"
+  client_instance_type = "t3.medium"
   ami                  = data.aws_ami.ubuntu.id
   subnet_ids           = module.network.private_subnet_ids
   key_name             = module.ssh.key_name

--- a/shared/nomad/jobs/influxdb.nomad.hcl
+++ b/shared/nomad/jobs/influxdb.nomad.hcl
@@ -78,8 +78,8 @@ EOF
       }
 
       resources {
-        cpu    = 200
-        memory = 256
+        cpu    = 500
+        memory = 700
       }
     }
   }


### PR DESCRIPTION
When actively collecting data, InfluxDB users more resources. Bump clients instance type to accommodate the extra and future load as well.