### PR TITLE
test-cluster: create host and group vars overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,3 @@ tls/
 
 # Test cluster nodesim jobs.
 **/*/jobs/nomad-nodesim-*
-
-# Test clusters configuration.
-test-cluster-*/
-!test-cluster-template/

--- a/infra/eu-west-2/core/main.tf
+++ b/infra/eu-west-2/core/main.tf
@@ -82,13 +82,13 @@ module "core_cluster" {
 
 resource "ansible_group" "server" {
   name      = "server"
-  children  = [module.core_cluster.ansible_group_server]
+  children  = [module.core_cluster.server_ansible_group]
   variables = local.ansible_default_vars
 }
 
 resource "ansible_group" "client" {
   name      = "client"
-  children  = [module.core_cluster.ansible_group_client]
+  children  = [module.core_cluster.client_ansible_group]
   variables = local.ansible_default_vars
 }
 

--- a/infra/eu-west-2/test-cluster-template/ansible.tf
+++ b/infra/eu-west-2/test-cluster-template/ansible.tf
@@ -24,7 +24,7 @@ EOT
 
 resource "ansible_group" "server" {
   name     = "server"
-  children = flatten([for k, v in module.clusters : v.ansible_group_server])
+  children = flatten([for k, v in module.clusters : v.server_ansible_group])
   variables = merge(
     local.ansible_default_vars,
     local.ansible_influxdb_telegraf_default_vars,
@@ -47,5 +47,62 @@ resource "ansible_host" "bastion" {
   groups = [ansible_group.bastion.name]
   variables = {
     ansible_host = data.terraform_remote_state.core.outputs.bastion_ip
+  }
+}
+
+# Can't use local_file resource with ignore_changes because the resource ID is
+# its hash, so changes are never ignored.
+# https://github.com/hashicorp/terraform-provider-local/issues/262
+resource "terraform_data" "host_vars" {
+  for_each = toset(flatten([for v, c in module.clusters : c.server_ansible_hosts]))
+
+  provisioner "local-exec" {
+    command = <<EOF
+mkdir -p ${path.module}/ansible/host_vars
+cat <<EOH > ${path.module}/ansible/host_vars/${each.key}.yaml
+# Variable overrides for host ${each.key}.
+#
+# This file is created by Terraform, but not managed, so it is not recreated if
+# deleted.
+#
+# Replace the resource to recreate this file.
+# ALL CHANGES WILL BE LOST.
+#   terraform apply -replace 'terraform_data.host_vars["${each.key}"]'
+EOH
+EOF
+  }
+
+  provisioner "local-exec" {
+    command = <<EOF
+rm -f ${path.module}/ansible/host_vars/${each.key}.yaml
+EOF
+    when    = destroy
+  }
+}
+
+resource "terraform_data" "group_vars" {
+  for_each = toset([for v, c in module.clusters : c.server_ansible_group])
+
+  provisioner "local-exec" {
+    command = <<EOF
+mkdir -p ${path.module}/ansible/group_vars
+cat <<EOH > ${path.module}/ansible/group_vars/${each.key}.yaml
+# Variable overrides for group ${each.key}.
+#
+# This file is created by Terraform, but not managed, so it is not recreated if
+# deleted.
+#
+# Replace the resource to recreate this file.
+# ALL CHANGES WILL BE LOST.
+#   terraform apply -replace 'terraform_data.group_vars["${each.key}"]'
+EOH
+EOF
+  }
+
+  provisioner "local-exec" {
+    command = <<EOF
+rm -f ${path.module}/ansible/group_vars/${each.key}.yaml
+EOF
+    when    = destroy
   }
 }

--- a/infra/eu-west-2/test-cluster-template/ansible/playbook.yaml
+++ b/infra/eu-west-2/test-cluster-template/ansible/playbook.yaml
@@ -12,10 +12,13 @@
     - role: common
     - role: nomad
       vars:
-        nomad_server_enabled: true
+        # Most variables are defined in the inventory with Terraform. You can
+        # customize values for specific hosts or groups using the files in
+        # host_vars/ and group_vars/.
+        #
+        # Run `nomad-inventory --graph --vars` to list all variables defined on
+        # each host and group.
         nomad_server_join_retry_join: ["{{ terraform_nomad_server_join }}"]
-        nomad_limits_http_max_conns_per_client: 0
-        nomad_limits_rpc_max_conns_per_client: 0
         nomad_custom_binary_source: "{{ build_nomad_local_code_path }}/pkg/linux_amd64/nomad"
     - role: influxdb_telegraf
       vars:

--- a/shared/terraform/modules/nomad-cluster/outputs.tf
+++ b/shared/terraform/modules/nomad-cluster/outputs.tf
@@ -6,8 +6,12 @@ output "server_private_ips" {
   value = aws_instance.servers.*.private_ip
 }
 
-output "ansible_group_server" {
+output "server_ansible_group" {
   value = ansible_group.server.name
+}
+
+output "server_ansible_hosts" {
+  value = [for h in ansible_host.server : h.name]
 }
 
 output "client_ids" {
@@ -18,6 +22,10 @@ output "client_private_ips" {
   value = aws_instance.clients.*.private_ip
 }
 
-output "ansible_group_client" {
+output "client_ansible_group" {
   value = ansible_group.client.name
+}
+
+output "client_ansible_hosts" {
+  value = [for h in ansible_host.client : h.name]
 }


### PR DESCRIPTION
Pre-create host_vars and group_vars files so it is easier to customize test cluster configuration.

Also remove test clusters from `.gitignore`. In hindsight it can be useful to be able to push their code, even if it not intended to be merged to `main`.