### PR TITLE
test-cluster: pull more data from state

### DIFF
--- a/infra/eu-west-2/core-nomad/influxdb.tf
+++ b/infra/eu-west-2/core-nomad/influxdb.tf
@@ -1,3 +1,7 @@
+locals {
+  influxdb_org_name = "nomad-eng"
+}
+
 resource "aws_ebs_volume" "influxdb" {
   availability_zone = "eu-west-2a"
   size              = 10
@@ -55,4 +59,10 @@ resource "nomad_variable" "influxdb" {
 
 resource "nomad_job" "influxdb" {
   jobspec = file("${path.module}/../../../shared/nomad/jobs/influxdb.nomad.hcl")
+
+  hcl2 {
+    vars = {
+      influxdb_org_name = local.influxdb_org_name
+    }
+  }
 }

--- a/infra/eu-west-2/core-nomad/outputs.tf
+++ b/infra/eu-west-2/core-nomad/outputs.tf
@@ -1,0 +1,3 @@
+output "influxdb_org_name" {
+  value = local.influxdb_org_name
+}

--- a/infra/eu-west-2/test-cluster-template/ansible.tf
+++ b/infra/eu-west-2/test-cluster-template/ansible.tf
@@ -1,18 +1,18 @@
 locals {
   ansible_default_vars = {
     ansible_user                 = "ubuntu"
-    ansible_ssh_private_key_file = abspath(var.ssh_key_path)
+    ansible_ssh_private_key_file = abspath(local_sensitive_file.ssh_key.filename)
     ansible_ssh_common_args      = <<EOT
 -o StrictHostKeyChecking=no
 -o IdentitiesOnly=yes
--o ProxyCommand="ssh -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i '${abspath(var.ssh_key_path)}' -W %h:%p -q ubuntu@${data.terraform_remote_state.core.outputs.bastion_ip}"
+-o ProxyCommand="ssh -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i '${abspath(local_sensitive_file.ssh_key.filename)}' -W %h:%p -q ubuntu@${data.terraform_remote_state.core.outputs.bastion_ip}"
 EOT
   }
 
   ansible_influxdb_telegraf_default_vars = {
     influxdb_telegraf_input_nomad_url            = "http://127.0.0.1:4646"
     influxdb_telegraf_output_token               = data.terraform_remote_state.core.outputs.influxdb_token
-    influxdb_telegraf_output_organization        = var.influxdb_org
+    influxdb_telegraf_output_organization        = data.terraform_remote_state.core_nomad.outputs.influxdb_org_name
     terraform_influxdb_telegraf_output_urls_json = jsonencode(formatlist("https://%s:8086", [data.terraform_remote_state.core.outputs.lb_private_ip]))
   }
 

--- a/infra/eu-west-2/test-cluster-template/clusters.tf
+++ b/infra/eu-west-2/test-cluster-template/clusters.tf
@@ -23,7 +23,7 @@ module "bootstrap" {
   source = "../../../shared/terraform/modules/test-bench-bootstrap"
 
   project_name             = var.project_name
-  influxdb_org_name        = var.influxdb_org
+  influxdb_org_name        = data.terraform_remote_state.core_nomad.outputs.influxdb_org_name
   influxdb_bucket_suffixes = keys(local.test_clusters)
 }
 
@@ -35,5 +35,11 @@ resource "local_file" "nodesim_jobs" {
     terraform_nodesim_job_namespace = module.bootstrap.nomad_namespace
     terraform_nodesim_job_servers   = module.clusters[each.key].server_private_ips
   })
-  filename = "jobs/nomad-nodesim-${each.key}.nomad.hcl"
+  filename = "${path.root}/jobs/nomad-nodesim-${each.key}.nomad.hcl"
+}
+
+resource "local_sensitive_file" "ssh_key" {
+  content         = data.terraform_remote_state.core.outputs.ssh_key
+  filename        = "${path.root}/keys/bench-core.pem"
+  file_permission = "0600"
 }

--- a/infra/eu-west-2/test-cluster-template/outputs.tf
+++ b/infra/eu-west-2/test-cluster-template/outputs.tf
@@ -14,7 +14,7 @@ Use the following commands to SSH into servers.
 %{for cluster in keys(module.clusters)~}
   ${cluster}:
 %{for server in module.clusters[cluster].server_private_ips~}
-    ssh -i ${var.ssh_key_path} -J ubuntu@${data.terraform_remote_state.core.outputs.bastion_ip} ubuntu@${server}
+    ssh -i ${local_sensitive_file.ssh_key.filename} -J ubuntu@${data.terraform_remote_state.core.outputs.bastion_ip} ubuntu@${server}
 %{endfor~}
 %{endfor~}
 
@@ -22,7 +22,7 @@ Or open an SSH tunnel to Nomad.
 %{for cluster in keys(module.clusters)~}
   ${cluster}:
 %{for server in module.clusters[cluster].server_private_ips~}
-    ssh -i ${var.ssh_key_path} -NL 4646:${server}:4646 ubuntu@${data.terraform_remote_state.core.outputs.bastion_ip}
+    ssh -i ${local_sensitive_file.ssh_key.filename} -NL 4646:${server}:4646 ubuntu@${data.terraform_remote_state.core.outputs.bastion_ip}
 %{endfor~}
 %{endfor~}
 

--- a/infra/eu-west-2/test-cluster-template/providers.tf
+++ b/infra/eu-west-2/test-cluster-template/providers.tf
@@ -33,6 +33,17 @@ data "terraform_remote_state" "core" {
   }
 }
 
+data "terraform_remote_state" "core_nomad" {
+  backend = "remote"
+
+  config = {
+    organization = "nomad-eng"
+    workspaces = {
+      name = "nomad-bench-core-nomad"
+    }
+  }
+}
+
 provider "aws" {
   region = "eu-west-2"
 }

--- a/infra/eu-west-2/test-cluster-template/variables.tf
+++ b/infra/eu-west-2/test-cluster-template/variables.tf
@@ -1,11 +1,3 @@
 variable "project_name" {
   type = string
 }
-
-variable "ssh_key_path" {
-  default = "../core/keys/bench-core.pem"
-}
-
-variable "influxdb_org" {
-  default = "nomad-eng"
-}


### PR DESCRIPTION
Pull the SSH key and InfluxDB organization name from remote state to avoid additional steps, such as running `make` from the core cluster folder, and make sure related data remain consistent.