### PR TITLE
nomad: fix check of server and client enabled vars

### DIFF
--- a/shared/ansible/roles/nomad/tasks/main.yaml
+++ b/shared/ansible/roles/nomad/tasks/main.yaml
@@ -53,7 +53,7 @@
     owner: "{{ nomad_user }}"
     group: "{{ nomad_group }}"
     mode: "0655"
-  when: nomad_server_enabled is true
+  when: nomad_server_enabled
   notify:
     - "restart_nomad"
 
@@ -65,7 +65,7 @@
     owner: "{{ nomad_user }}"
     group: "{{ nomad_group }}"
     mode: "0655"
-  when: nomad_client_enabled is true
+  when: nomad_client_enabled
   notify:
     - "restart_nomad"
 


### PR DESCRIPTION
Ansible boolean values are weird. A YAML `true` is internally represented as a Python `True`, so it's different from `true`, meaning the conditional `is true` may fail depending on how the variable is defined.