### PR TITLE
influx: ensure the service is always started

### DIFF
--- a/shared/ansible/roles/influxdb_telegraf/tasks/main.yaml
+++ b/shared/ansible/roles/influxdb_telegraf/tasks/main.yaml
@@ -63,3 +63,10 @@
     mode: "0755"
   notify:
     - "reload_systemd"
+
+- name: "start_influx_telegraf_service"
+  become: true
+  ansible.builtin.service:
+    name: "influxdb_telegraf"
+    state: "started"
+    enabled: true


### PR DESCRIPTION
Ansible handlers have the following behaviours:
  - only run at the end of the playbook.
  - only run if a task that triggers it changes something (`changed` instead of `ok`).
  - only run on hosts that did not fail.

This means that, without an explicit task to enable and start the service, InfluxDB may not run if the playbook fails after the config file is created, even after running the playbook again.

This happens because the tasks that call the `restart_influxdb_telegraf` handler are idempotent, meaning the will only run once. If a later task fails, the host as whole is considered as failed for the run, and the trigger is not called on them.

Running the playbook again has not effect since those tasks will not change.

Forcing the service state signals to Ansible that it should always make sure the service is running.