### PR TITLE
core: fix `NOMAD_CACERT` output value

### DIFF
--- a/infra/eu-west-2/core/output.tf
+++ b/infra/eu-west-2/core/output.tf
@@ -19,7 +19,7 @@ SSH into the bastion host:
 
 Export the environment variables necessary to access the Nomad cluster:
   export NOMAD_ADDR=https://${module.core_cluster_lb.lb_public_ip}:443
-  export NOMAD_CACERT="${path.module}/tls/nomad-agent-ca.pem"
+  export NOMAD_CACERT="$PWD/tls/nomad-agent-ca.pem"
 
 If this is a new cluster, bootstrap the ACL system and store the token
 somewhere safe. Export it as the NOMAD_TOKEN environment variable.


### PR DESCRIPTION
The value of `path.module` is relative to where the file is defined, so the output value will be `./tls/nomad-agent-ca.pem`, which does not work when a `nomad` command is executed in any other directory.

With Terraform running in a remote runner, we can't use the `abspath` function because it will resolved to a path inside the runner.

The `$PWD` environment variable will be expanded when running the `export` commands.