### PR TITLE
nodesim: spread clients over 2 DCs

### DIFF
--- a/shared/terraform/modules/test-bench-bootstrap/nomad-nodesim.nomad.hcl.tpl
+++ b/shared/terraform/modules/test-bench-bootstrap/nomad-nodesim.nomad.hcl.tpl
@@ -43,7 +43,7 @@ node {
 EOH
 
         change_mode = "restart"
-        destination = "$${NOMAD_TASK_DIR}/config.hcl"
+        destination = "#{NOMAD_TASK_DIR}/config.hcl"
       }
 
       resources {
@@ -81,7 +81,7 @@ node {
 EOH
 
         change_mode = "restart"
-        destination = "$${NOMAD_TASK_DIR}/config.hcl"
+        destination = "#{NOMAD_TASK_DIR}/config.hcl"
       }
 
       resources {


### PR DESCRIPTION
This shouldn't affect other tests but gives us more flexibility for when we want to spread jobs across. 