### PR TITLE
influxdb: expand session length and fix typo

### DIFF
--- a/shared/nomad/jobs/influxdb.nomad.hcl
+++ b/shared/nomad/jobs/influxdb.nomad.hcl
@@ -51,6 +51,7 @@ job "influxdb" {
         ports = ["influxdb"]
         args = [
           "--http-bind-address=0.0.0.0:8086",
+          "--session-length=600",
         ]
       }
 
@@ -73,7 +74,7 @@ DOCKER_INFLUXDB_INIT_PASSWORD={{.admin_password}}
 DOCKER_INFLUXDB_INIT_ADMIN_TOKEN={{.admin_token}}
 {{end}}
 EOF
-        destination = "${NOMAD_SECRET_DIR}/env"
+        destination = "${NOMAD_SECRETS_DIR}/env"
         env         = true
       }
 


### PR DESCRIPTION
The default session length is 1h, which forces us to login multiple times in a day. Expand this value to 10h.

Also fixes a type that causes the environment template to be rendered in a folder called `${NOMAD_SECRET_DIR}` instead of using the secrets directory.