### PR TITLE
ansible: add option to enable Nomad debug endpoints.

### DIFF
--- a/shared/ansible/roles/nomad/defaults/main.yaml
+++ b/shared/ansible/roles/nomad/defaults/main.yaml
@@ -13,6 +13,7 @@ nomad_log_level: "DEBUG"
 nomad_log_json: true
 nomad_log_include_location: true
 nomad_log_file: "/var/log/nomad.log"
+nomad_enable_debug: false
 
 nomad_server_enabled: false
 nomad_server_bootstrap_expect: 3

--- a/shared/ansible/roles/nomad/templates/base.hcl.j2
+++ b/shared/ansible/roles/nomad/templates/base.hcl.j2
@@ -6,6 +6,8 @@ log_json             = {{ nomad_log_json | lower }}
 log_include_location = {{ nomad_log_include_location | lower }}
 log_file             = "{{ nomad_log_file }}"
 
+enable_debug = {{ nomad_enable_debug | lower }}
+
 limits {
   https_handshake_timeout   = "{{ nomad_limits_https_handshake_timeout }}"
   http_max_conns_per_client = {{ nomad_limits_http_max_conns_per_client }}


### PR DESCRIPTION
This will be useful if we find specific area or problems that require further debug detail such as pprof dumps.