### PR TITLE
telegraf: add interval agent configuration option.

### DIFF
--- a/shared/ansible/roles/influxdb_telegraf/defaults/main.yaml
+++ b/shared/ansible/roles/influxdb_telegraf/defaults/main.yaml
@@ -12,10 +12,13 @@ influxdb_telegraf_arch_map:
 influxdb_telegraf_url: "https://dl.influxdata.com/telegraf/releases/telegraf-{{ influxdb_telegraf_version }}_{{ ansible_system | lower }}_{{ influxdb_telegraf_arch_map[ansible_architecture] }}.tar.gz"
 influxdb_telegraf_tar_file: "telegraf-{{ influxdb_telegraf_version }}"
 
+influxdb_telegraf_agent_interval : "10s"
+
 influxdb_telegraf_input_nomad_enabled: true
+influxdb_telegraf_input_nomad_interval: "10s"
 influxdb_telegraf_input_nomad_url: "http://127.0.0.1:4646"
 influxdb_telegraf_input_nomad_tls_ca: ""
-influxdb_telegraf_inout_nomad_log_file: "/var/log/nomad.log"
+influxdb_telegraf_input_nomad_log_file: "/var/log/nomad.log"
 influxdb_telegraf_output_urls: ["http://127.0.0.1:8086"]
 influxdb_telegraf_output_token: ""
 influxdb_telegraf_output_organization: ""

--- a/shared/ansible/roles/influxdb_telegraf/templates/base.conf.j2
+++ b/shared/ansible/roles/influxdb_telegraf/templates/base.conf.j2
@@ -1,8 +1,12 @@
+[agent]
+  interval = "{{ influxdb_telegraf_agent_interval }}"
+
 {% if influxdb_telegraf_input_nomad_enabled -%}
 [[inputs.nomad]]
-  url    = "{{ influxdb_telegraf_input_nomad_url }}"
+  interval = "{{ influxdb_telegraf_input_nomad_interval }}"
+  url      = "{{ influxdb_telegraf_input_nomad_url }}"
   {% if influxdb_telegraf_input_nomad_tls_ca != "" -%}
-  tls_ca = "{{ influxdb_telegraf_input_nomad_tls_ca }}"
+  tls_ca   = "{{ influxdb_telegraf_input_nomad_tls_ca }}"
   {% endif -%}
 {% endif %}
 
@@ -30,7 +34,7 @@
 [[inputs.net]]
 
 [[inputs.tail]]
-  files              = ["{{ influxdb_telegraf_inout_nomad_log_file }}"]
+  files              = ["{{ influxdb_telegraf_input_nomad_log_file }}"]
   data_format        = "json"
   json_string_fields = ["@level", "@module", "@message", "@caller"]
   json_time_key      = "@timestamp"


### PR DESCRIPTION
This change allows us to configure the overall agent interval, as well as the Nomad input interval. When running Nomad with non-default in-memory intervals and retention periods, we need to modify the telegraf interval, otherwise we will miss data.