### PR TITLE
nomad: allow setting arbitrary Nomad configuration

### DIFF
--- a/shared/ansible/roles/nomad/defaults/main.yaml
+++ b/shared/ansible/roles/nomad/defaults/main.yaml
@@ -3,6 +3,7 @@ nomad_pkg_version: "" # defaults to latest
 nomad_user: root
 nomad_group: root
 nomad_config_dir: "/etc/nomad.d/"
+nomad_config_extra: ""
 
 nomad_install_dir: "/usr/bin"
 nomad_custom_binary_source: ""

--- a/shared/ansible/roles/nomad/tasks/main.yaml
+++ b/shared/ansible/roles/nomad/tasks/main.yaml
@@ -99,6 +99,18 @@
   notify:
     - "restart_nomad"
 
+- name: "create_additional_nomad_config_file"
+  become: true
+  ansible.builtin.copy:
+    content: "{{ nomad_config_extra }}"
+    dest: "{{ nomad_config_dir }}/99-extra.hcl"
+    owner: "{{ nomad_user }}"
+    group: "{{ nomad_group }}"
+    mode: "0655"
+  when: nomad_config_extra != ""
+  notify:
+    - "restart_nomad"
+
 - name: "host_volume"
   ansible.builtin.include_tasks:
     file: host_volume.yaml


### PR DESCRIPTION
The `nomad_config_extra` variable receives a string that is written to a high precedence configuration file, meaning it overwrite other configuration.

This is useful when testing scenarios where agents need to be configured in a particular way that is not exposed via Ansible variables.

For example, to disable scheduling works in a host it's possible to write this to `host_vars/test-cluster-*.yaml`.

```yaml
nomad_config_extra: |
  server {
    num_schedulers = 0
  }
```