### PR TITLE
nodesim: mount cgroup host path

### DIFF
--- a/infra/eu-west-2/core/ansible/playbook_client.yaml
+++ b/infra/eu-west-2/core/ansible/playbook_client.yaml
@@ -21,6 +21,8 @@
           docker:
             config:
               allow_privileged: true
+              volumes:
+                enabled: true
           raw_exec:
             config:
               enabled: true

--- a/shared/terraform/modules/test-bench-bootstrap/nomad-nodesim.nomad.hcl.tpl
+++ b/shared/terraform/modules/test-bench-bootstrap/nomad-nodesim.nomad.hcl.tpl
@@ -30,6 +30,9 @@ job "${terraform_job_name}" {
           "-server-addr=${addr}",
 %{ endfor ~}
         ]
+        volumes = [
+          "/sys/fs/cgroup:/sys/fs/cgroup",
+        ]
       }
 
       template {
@@ -67,6 +70,9 @@ EOH
 %{ for addr in terraform_job_servers ~}
           "-server-addr=${addr}",
 %{ endfor ~}
+        ]
+        volumes = [
+          "/sys/fs/cgroup:/sys/fs/cgroup",
         ]
       }
 


### PR DESCRIPTION
PR https://github.com/hashicorp/nomad/pull/19915 added an explicit error check to prevent silent failures when clients are unable to properly setup cgroups.

This prevents `nomad-nodesim` jobs to start unless `/sys/fs/cgroup` is available for write inside the container.

Since `nomad-nodesim` doesn't run real allocations, mounting the host path _should_ be fine (famous last words).