### PR TITLE
core: bump server count to 3

### DIFF
--- a/infra/eu-west-2/core/ansible/playbook_server.yaml
+++ b/infra/eu-west-2/core/ansible/playbook_server.yaml
@@ -5,7 +5,7 @@
     - role: nomad
       vars:
         nomad_server_enabled: true
-        nomad_server_bootstrap_expect: 1
+        nomad_server_bootstrap_expect: 3
         nomad_server_join_retry_join: ["{{ terraform_nomad_server_join }}"]
         nomad_limits_http_max_conns_per_client: 0
         nomad_limits_rpc_max_conns_per_client: 0

--- a/infra/eu-west-2/core/main.tf
+++ b/infra/eu-west-2/core/main.tf
@@ -70,7 +70,7 @@ module "core_cluster" {
   source = "../../../shared/terraform/modules/nomad-cluster"
 
   project_name         = var.project_name
-  server_count         = 1
+  server_count         = 3
   server_instance_type = "t3.medium"
   client_count         = 2
   client_instance_type = "t3.medium"


### PR DESCRIPTION
Now that we have more things running in the core cluster it is best to bump the server count to 3 for additional redundancy.