### PR TITLE
nomad-load: update CLI flags and fix mock task

### DIFF
--- a/shared/terraform/modules/test-bench-bootstrap/nomad-load.nomad.hcl.tpl
+++ b/shared/terraform/modules/test-bench-bootstrap/nomad-load.nomad.hcl.tpl
@@ -23,9 +23,9 @@ job "${terraform_job_name}" {
         data        = <<EOF
 #!/usr/bin/env bash
 
-timeout 60 nomad-load -port={{env "NOMAD_PORT_nomad_load"}} -rate=1 -workers=100
+timeout 60 nomad-load -driver=mock -http-port={{env "NOMAD_PORT_nomad_load"}} -rate=1 -workers=100
 sleep 10
-timeout 60 nomad-load -port={{env "NOMAD_PORT_nomad_load"}} -rate=10 -workers=100
+timeout 60 nomad-load -driver=mock -http-port={{env "NOMAD_PORT_nomad_load"}} -rate=10 -workers=100
 sleep 10
 exit 0
 EOF

--- a/tools/nomad-load/internal/job.nomad.hcl.tpl
+++ b/tools/nomad-load/internal/job.nomad.hcl.tpl
@@ -24,7 +24,11 @@ job "test_job_{{$w}}_{{$c}}" {
     count = {{ $c }}
     {{ if eq $d "mock" }}
     task "test_job_task_{{$w}}_{{$c}}_{{$i}}" {
-      driver = "mock"
+      driver = "mock_driver"
+
+      config {
+        run_for = "10s"
+      }
     }
     {{ else if eq $d "docker" }}
     task "echo" {


### PR DESCRIPTION
Use the new flags and fix the mock driver name and configuration.