### PR TITLE
shared: use real alloc runner in nodesim job

### DIFF
--- a/shared/terraform/modules/test-bench-bootstrap/nomad-nodesim.nomad.hcl.tpl
+++ b/shared/terraform/modules/test-bench-bootstrap/nomad-nodesim.nomad.hcl.tpl
@@ -26,6 +26,7 @@ job "${terraform_job_name}" {
           "-node-num=50",
           "-work-dir=#{NOMAD_TASK_DIR}",
           "-config=#{NOMAD_TASK_DIR}/config.hcl",
+          "-alloc-runner-type=real",
 %{ for addr in terraform_job_servers ~}
           "-server-addr=${addr}",
 %{ endfor ~}
@@ -52,7 +53,7 @@ EOH
 
       resources {
         cpu    = 150
-        memory = 256
+        memory = 512
       }
     }
 
@@ -68,6 +69,7 @@ EOH
           "-node-num=50",
           "-work-dir=#{NOMAD_TASK_DIR}",
           "-config=#{NOMAD_TASK_DIR}/config.hcl",
+          "-alloc-runner-type=real",
 %{ for addr in terraform_job_servers ~}
           "-server-addr=${addr}",
 %{ endfor ~}
@@ -94,7 +96,7 @@ EOH
 
       resources {
         cpu    = 150
-        memory = 256
+        memory = 512
       }
     }
   }


### PR DESCRIPTION
Use new flag `-alloc-runner-type` introduced in
https://github.com/hashicorp-forge/nomad-nodesim/pull/24 to spawn real alloc runners in nodesim, allowing test loads to use the mock driver with real configuration.

Also bumps memory reservation to account for the additional load.