### PR TITLE
nomad-load: Support Prometheus and JSON format output metrics.

### DIFF
--- a/tools/nomad-load/go.mod
+++ b/tools/nomad-load/go.mod
@@ -5,6 +5,7 @@ go 1.22.1
 require (
 	github.com/hashicorp/go-hclog v1.6.2
 	github.com/hashicorp/go-metrics v0.5.3
+	github.com/hashicorp/go-msgpack v1.1.6-0.20240304204939-8824e8ccc35f
 	github.com/hashicorp/nomad v1.7.6
 	github.com/hashicorp/nomad/api v0.0.0-20240327201139-6ad648bec8e8
 	github.com/prometheus/client_golang v1.19.0

--- a/tools/nomad-load/go.sum
+++ b/tools/nomad-load/go.sum
@@ -77,6 +77,8 @@ github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJ
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-metrics v0.5.3 h1:M5uADWMOGCTUNU1YuC4hfknOeHNaX54LDm4oYSucoNE=
 github.com/hashicorp/go-metrics v0.5.3/go.mod h1:KEjodfebIOuBYSAe/bHTm+HChmKSxAOXPBieMLYozDE=
+github.com/hashicorp/go-msgpack v1.1.6-0.20240304204939-8824e8ccc35f h1:/xqzTen8ftnKv3cKa87WEoOLtsDJYFU0ArjrKaPTTkc=
+github.com/hashicorp/go-msgpack v1.1.6-0.20240304204939-8824e8ccc35f/go.mod h1:gWVc3sv/wbDmR3rQsj1CAktEZzoz1YNK9NfGLXJ69/4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
@@ -201,6 +203,7 @@ golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/net v0.0.0-20180811021610-c39426892332/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -209,6 +212,7 @@ golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
 golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
@@ -239,6 +243,7 @@ golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/time v0.5.0 h1:o7cqy6amK/52YcAKIPlM3a+Fpj35zvRj2TP+e1xFSfk=
 golang.org/x/time v0.5.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20190424220101-1e8e1cfdf96b/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=

--- a/tools/nomad-load/internal/http/error.go
+++ b/tools/nomad-load/internal/http/error.go
@@ -1,0 +1,30 @@
+package http
+
+// errInvalidMethod is the error message used when a HTTP request is sent using
+// the incorrect method.
+const errInvalidMethod = "Invalid method"
+
+// codedError defines the interface used for custom HTTP error handling. It
+// ensures we include a message and response code to differentiate between
+// internal and other errors.
+type codedError interface {
+	error
+	Code() int
+}
+
+// Ensure codedErrorImpl satisfies the codedError interface.
+var _ codedError = (*codedErrorImpl)(nil)
+
+// codedErrorImpl implements the codedError interface.
+type codedErrorImpl struct {
+	s    string
+	code int
+}
+
+// newCodedError creates a new coded error.
+func newCodedError(c int, s string) *codedErrorImpl {
+	return &codedErrorImpl{s, c}
+}
+
+func (e *codedErrorImpl) Error() string { return e.s }
+func (e *codedErrorImpl) Code() int     { return e.code }

--- a/tools/nomad-load/internal/http/http.go
+++ b/tools/nomad-load/internal/http/http.go
@@ -1,0 +1,121 @@
+package http
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-metrics"
+	"github.com/hashicorp/go-msgpack/codec"
+)
+
+type Server struct {
+	log hclog.Logger
+	ln  net.Listener
+	mux *http.ServeMux
+	srv *http.Server
+
+	inMemorySink *metrics.InmemSink
+}
+
+func NewServer(logger hclog.Logger, addr, port string, sink *metrics.InmemSink) (*Server, error) {
+
+	srv := &Server{
+		log:          logger.Named("http_server"),
+		mux:          http.NewServeMux(),
+		inMemorySink: sink,
+	}
+
+	// Setup our handlers.
+	srv.mux.HandleFunc("/v1/metrics", srv.wrap(srv.getMetrics))
+
+	// Configure the HTTP server to the most basic level.
+	srv.srv = &http.Server{
+		Addr:         fmt.Sprintf("%s:%v", addr, port),
+		Handler:      srv.mux,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 15 * time.Second,
+		IdleTimeout:  15 * time.Second,
+	}
+
+	return srv, nil
+
+}
+
+func (s *Server) Server() *http.Server { return s.srv }
+
+// wrap is a helper for all HTTP handler functions providing common
+// functionality including logging and error handling.
+func (s *Server) wrap(handler func(w http.ResponseWriter, r *http.Request) (interface{}, error)) func(w http.ResponseWriter, r *http.Request) {
+	f := func(w http.ResponseWriter, r *http.Request) {
+
+		start := time.Now()
+
+		// Defer a function which allows us to log the time taken to fulfill
+		// the HTTP request.
+		defer func() {
+			s.log.Trace("request complete", "method", r.Method,
+				"path", r.URL, "duration", time.Since(start))
+		}()
+
+		// Handle the request, allowing us to the get response object and any
+		// error from the endpoint.
+		obj, err := handler(w, r)
+		if err != nil {
+			s.handleHTTPError(w, r, err)
+			return
+		}
+
+		// If we have a response object, encode it.
+		if obj != nil {
+			var buf bytes.Buffer
+
+			enc := codec.NewEncoder(&buf, &codec.JsonHandle{HTMLCharsAsIs: true})
+
+			// Encode the object. If we fail to do this, handle the error so
+			// that this can be passed to the operator.
+			err := enc.Encode(obj)
+			if err != nil {
+				s.handleHTTPError(w, r, err)
+				return
+			}
+
+			//  Set the content type header and write the data to the HTTP
+			//  reply.
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(buf.Bytes())
+		}
+	}
+
+	return f
+}
+
+// handleHTTPError is used to handle HTTP handler errors within the wrap func.
+// It sets response headers where required and ensure appropriate errors are
+// logged.
+func (s *Server) handleHTTPError(w http.ResponseWriter, r *http.Request, err error) {
+
+	// Start with a default internal server error and the error message
+	// that was returned.
+	code := http.StatusInternalServerError
+	errMsg := err.Error()
+
+	// If the error was a custom codedError update the response code to
+	// that of the wrapped error.
+	if codedErr, ok := err.(codedError); ok {
+		code = codedErr.Code()
+	}
+
+	// Write the status code header.
+	w.WriteHeader(code)
+
+	// Write the response body. If we get an error, log this as it will
+	// provide some operator insight if this happens regularly.
+	if _, wErr := w.Write([]byte(errMsg)); wErr != nil {
+		s.log.Error("failed to write response error", "error", wErr)
+	}
+	s.log.Error("request failed", "method", r.Method, "path", r.URL, "error", errMsg, "code", code)
+}

--- a/tools/nomad-load/internal/http/metrics.go
+++ b/tools/nomad-load/internal/http/metrics.go
@@ -1,0 +1,43 @@
+package http
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var (
+	// Only create the prometheus handler once
+	promHandler http.Handler
+	promOnce    sync.Once
+)
+
+func (s *Server) getMetrics(w http.ResponseWriter, r *http.Request) (interface{}, error) {
+
+	// Only allow GET requests on this endpoint.
+	if r.Method != http.MethodGet {
+		return nil, newCodedError(http.StatusMethodNotAllowed, errInvalidMethod)
+	}
+
+	if format := r.URL.Query().Get("format"); format == "prometheus" {
+		s.getPrometheusMetrics().ServeHTTP(w, r)
+		return nil, nil
+	}
+	return s.inMemorySink.DisplayMetrics(w, r)
+}
+
+// getPrometheusMetrics is the getMetrics handler when the caller wishes to
+// view them in Prometheus format.
+func (s *Server) getPrometheusMetrics() http.Handler {
+	promOnce.Do(func() {
+		handlerOptions := promhttp.HandlerOpts{
+			ErrorLog:           s.log.Named("prometheus").StandardLogger(nil),
+			ErrorHandling:      promhttp.ContinueOnError,
+			DisableCompression: true,
+		}
+		promHandler = promhttp.HandlerFor(prometheus.DefaultGatherer, handlerOptions)
+	})
+	return promHandler
+}

--- a/tools/nomad-load/internal/telemetry/telemetry.go
+++ b/tools/nomad-load/internal/telemetry/telemetry.go
@@ -1,0 +1,42 @@
+package telemetry
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-metrics"
+	"github.com/hashicorp/go-metrics/prometheus"
+)
+
+// Setup is used to setup the telemetry sub-systems and returns the in-memory
+// sink to be used in http configuration.
+func Setup() (*metrics.InmemSink, error) {
+
+	inm := metrics.NewInmemSink(1*time.Second, 1*time.Minute)
+	metrics.DefaultInmemSignal(inm)
+
+	metricsConf := metrics.DefaultConfig("nomad-load")
+
+	var fanout metrics.FanoutSink
+
+	// Configure the Prometheus sink.
+	prometheusOpts := prometheus.PrometheusOpts{
+		Expiration: 1 * time.Minute,
+	}
+
+	sink, err := prometheus.NewPrometheusSinkFrom(prometheusOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup Promtheus sink: %v", err)
+	}
+	fanout = append(fanout, sink)
+
+	// Add the in-memory sink to the fanout.
+	fanout = append(fanout, inm)
+
+	// Initialize the global sink.
+	_, err = metrics.NewGlobal(metricsConf, fanout)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup global sink: %v", err)
+	}
+	return inm, nil
+}


### PR DESCRIPTION
This change modifies the HTTP server, so that it now supports both JSON and Prometheus formatted metrics. This adds flexibility and means we can scrape the endpoint and locally look at JSON data rather than having to understand and parse the more confusing Prometheus output.

The interval and retention values are currently hardcoded to a more aggressive value. This seems OK initially, as we want to ingest this data at a high frequency for accuracy. In the future, we may want to make this configurable.