### PR TITLE
nomad: add test cluster Nomad GC job to avoid memory exhaustion.

### DIFF
--- a/shared/terraform/modules/test-bench-bootstrap/nomad-gc.nomad.hcl.tpl
+++ b/shared/terraform/modules/test-bench-bootstrap/nomad-gc.nomad.hcl.tpl
@@ -1,0 +1,33 @@
+job "${terraform_job_name}" {
+  type      = "service"
+  namespace = "${terraform_job_namespace}"
+
+  group "nomad-gc" {
+
+    task "nomad-gc" {
+      driver = "docker"
+
+      config {
+        image   = "curlimages/curl:latest"
+        command = "/bin/sh"
+        args    = ["#{NOMAD_TASK_DIR}/script.sh"]
+      }
+
+      template {
+        data        = <<EOF
+#!/usr/bin/env sh
+
+while true; do
+  sleep 60
+  curl --request PUT ${terraform_nomad_addr}/v1/system/gc
+done
+EOF
+        destination = "#{NOMAD_TASK_DIR}/script.sh"
+      }
+
+      env {
+        NOMAD_ADDR = "${terraform_nomad_addr}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
When performing load testing with dispatch jobs, Nomads in-memory DB grows exponentially and can exhaust the hosts memory. This change adds a job that can be run on test clusters to periodically force Nomads GC to run.