### PR TITLE
nomad-load: differentiate `mock_driver` jobs on each dispatch/update

### DIFF
--- a/tools/nomad-load/internal/job.nomad.hcl.tpl
+++ b/tools/nomad-load/internal/job.nomad.hcl.tpl
@@ -27,7 +27,8 @@ job "test_job_{{$w}}_{{$c}}" {
       driver = "mock_driver"
 
       config {
-        run_for = "10s"
+        run_for       = "10s"
+        stdout_string = "{{ $e }}"
       }
     }
     {{ else if eq $d "docker" }}


### PR DESCRIPTION
We used to differentiate only docker-driver jobs, which we mostly don't use anyway. This is useful to make sure that jobs get updated or knowing when they got updated.