### PR TITLE
test-bench-bootstrap: make nodesim memory a variable

### DIFF
--- a/infra/eu-west-2/test-cluster-template/main.tf
+++ b/infra/eu-west-2/test-cluster-template/main.tf
@@ -48,6 +48,7 @@ module "bootstrap" {
   clusters          = module.clusters
   ssh_key_path      = local_sensitive_file.ssh_key.filename
   bastion_ip        = data.terraform_remote_state.core.outputs.bastion_ip
+  nodesim_memory    = 512
 }
 
 resource "local_sensitive_file" "ssh_key" {

--- a/shared/terraform/modules/test-bench-bootstrap/nomad-nodesim.nomad.hcl.tpl
+++ b/shared/terraform/modules/test-bench-bootstrap/nomad-nodesim.nomad.hcl.tpl
@@ -53,7 +53,7 @@ EOH
 
       resources {
         cpu    = 150
-        memory = 2048
+        memory = ${nodesim_memory}
       }
     }
 
@@ -96,7 +96,7 @@ EOH
 
       resources {
         cpu    = 150
-        memory = 2048
+        memory = ${nodesim_memory}
       }
     }
   }

--- a/shared/terraform/modules/test-bench-bootstrap/nomad.tf
+++ b/shared/terraform/modules/test-bench-bootstrap/nomad.tf
@@ -5,6 +5,7 @@ locals {
       terraform_job_name      = "nomad-nodesim-${name}"
       terraform_job_namespace = nomad_namespace.nomad_bench.name
       terraform_job_servers   = cluster.server_private_ips
+      nodesim_memory          = var.nodesim_memory
     },
   ) }
 

--- a/shared/terraform/modules/test-bench-bootstrap/variables.tf
+++ b/shared/terraform/modules/test-bench-bootstrap/variables.tf
@@ -40,3 +40,9 @@ variable "ssh_key_path" {
 variable "bastion_ip" {
   type = string
 }
+
+variable "nodesim_memory" {
+  description = "The memory to allocate to the nodesim job."
+  type        = number
+  default     = 512
+}


### PR DESCRIPTION
For testing service jobs (and updates), 512M is nowhere near enough.