### PR TITLE
test-bench-bootstrap: make telegraf task poststart

### DIFF
--- a/shared/terraform/modules/test-bench-bootstrap/nomad-load.nomad.hcl.tpl
+++ b/shared/terraform/modules/test-bench-bootstrap/nomad-load.nomad.hcl.tpl
@@ -43,7 +43,7 @@ EOF
       driver = "docker"
 
       lifecycle {
-        hook    = "prestart"
+        hook    = "poststart"
         sidecar = true
       }
 


### PR DESCRIPTION
Avoids situations in which telegraf cannot connect to nomad-load because it hasn't started yet.