### PR TITLE
tf: use HashiCorp Preview Docker Hub images in Nomad jobs.

### DIFF
--- a/shared/terraform/modules/test-bench-bootstrap/nomad-load.nomad.hcl.tpl
+++ b/shared/terraform/modules/test-bench-bootstrap/nomad-load.nomad.hcl.tpl
@@ -13,7 +13,7 @@ job "${terraform_job_name}" {
       driver = "docker"
 
       config {
-        image   = "jrasell/nomad-load:latest"
+        image   = "hashicorppreview/nomad-bench-load:4e1ffce"
         command = "/bin/sh"
         args    = ["#{NOMAD_TASK_DIR}/script.sh"]
         ports   = ["nomad-load"]

--- a/shared/terraform/modules/test-bench-bootstrap/nomad-nodesim.nomad.hcl.tpl
+++ b/shared/terraform/modules/test-bench-bootstrap/nomad-nodesim.nomad.hcl.tpl
@@ -20,7 +20,7 @@ job "${terraform_job_name}" {
 
       config {
         privileged = true
-        image      = "jrasell/nomad-nodesim:latest"
+        image      = "hashicorppreview/nomad-nodesim:6cebba3"
         command    = "nomad-nodesim"
         args = [
           "-node-num=50",


### PR DESCRIPTION
closes #141 