### PR TITLE
ansible: correctly handle non-default Nomad local code paths.

### DIFF
--- a/shared/ansible/hashicorp/nomad_bench/roles/build/defaults/main.yaml
+++ b/shared/ansible/hashicorp/nomad_bench/roles/build/defaults/main.yaml
@@ -9,3 +9,4 @@ build_apt_packages: [
 
 build_user: "ubuntu"
 build_nomad_local_code_path: ""
+build_nomad_local_code_dir_name: "{{ build_nomad_local_code_path | split('/') | last }}"

--- a/shared/ansible/hashicorp/nomad_bench/roles/build/tasks/main.yaml
+++ b/shared/ansible/hashicorp/nomad_bench/roles/build/tasks/main.yaml
@@ -42,17 +42,17 @@
 
   - name: "remove_nomad_binary"
     ansible.builtin.file:
-      path:  "/home/{{ build_user }}/nomad/pkg/linux_amd64/nomad"
+      path:  "/home/{{ build_user }}/{{ build_nomad_local_code_dir_name }}/pkg/linux_amd64/nomad"
       state: "absent"
 
   - name: "build_nomad_binary"
     shell: ". /etc/profile;make pkg/linux_amd64/nomad"
     args:
-      chdir: "/home/{{ build_user }}/nomad"
+      chdir: "/home/{{ build_user }}/{{ build_nomad_local_code_dir_name }}"
 
   - name: "fetch_nomad_compiled_binary"
     ansible.builtin.fetch:
-      src: "/home/{{ build_user }}/nomad/pkg/linux_amd64/nomad"
+      src: "/home/{{ build_user }}/{{ build_nomad_local_code_dir_name }}/pkg/linux_amd64/nomad"
       dest: "{{ build_nomad_local_code_path }}/pkg/linux_amd64/nomad"
       flat: yes
 


### PR DESCRIPTION
When using the remote build functionality, the local Nomad code path was expected to be "nomad". This isn't the case for many people, and therefore this change fixes the behaviour, so we can handle all Nomad local code path names.